### PR TITLE
Corrected SplitMendableFlagPairs

### DIFF
--- a/gap/PolygonalComplexes/modification.gd
+++ b/gap/PolygonalComplexes/modification.gd
@@ -1957,11 +1957,26 @@ DeclareAttribute( "SplitCuttableEdges", IsPolygonalComplex );
 #! >            verts1 := VerticesOfEdges(complex)[pair[1]];
 #! >            verts2 := VerticesOfEdges(complex)[pair[2]];
 #! >            if IsEmpty(Intersection(verts1, verts2)) then
-#! >                Append( flagPairs, [ 
-#! >                    Set( [ [ verts1[1], pair[1] ], [ verts2[1], pair[2] ] ] ),
-#! >                    Set( [ [ verts1[1], pair[1] ], [ verts2[2], pair[2] ] ] ),
-#! >                    Set( [ [ verts1[2], pair[1] ], [ verts2[1], pair[2] ] ] ),
-#! >                    Set( [ [ verts1[2], pair[1] ], [ verts2[2], pair[2] ] ] )] );
+#! >                if not [verts1[1],verts2[1]] in VerticesOfEdges(complex) and
+#! >                   not [verts2[1],verts1[1]] in VerticesOfEdges(complex) then
+#! >                	Add(flagPairs,Set([ [ verts1[1], pair[1] ],
+#! > 				[ verts2[1], pair[2] ] ]));
+#! >                fi;
+#! >                if not [verts1[1],verts2[2]] in VerticesOfEdges(complex) and
+#! >                   not [verts2[2],verts1[1]] in VerticesOfEdges(complex) then
+#! >                	Add(flagPairs,Set([ [ verts1[1], pair[1] ],
+#! > 				[ verts2[2], pair[2] ] ]));
+#! >                fi;
+#! >                if not [verts1[2],verts2[1]] in VerticesOfEdges(complex) and
+#! >                   not [verts2[1],verts1[2]] in VerticesOfEdges(complex) then
+#! >                	Add(flagPairs,Set([ [ verts1[2], pair[1] ],
+#! > 				[ verts2[1], pair[2] ] ]));
+#! >                fi;
+#! >                if not [verts1[2],verts2[2]] in VerticesOfEdges(complex) and
+#! >                   not [verts2[2],verts1[2]] in VerticesOfEdges(complex) then
+#! >                	Add(flagPairs,Set([ [ verts1[2], pair[1] ],
+#! > 				[ verts2[2], pair[2] ] ]));
+#! >                fi;
 #! >            fi;
 #! >        od;
 #! >    

--- a/gap/PolygonalComplexes/modification.gd
+++ b/gap/PolygonalComplexes/modification.gd
@@ -1957,23 +1957,23 @@ DeclareAttribute( "SplitCuttableEdges", IsPolygonalComplex );
 #! >            verts1 := VerticesOfEdges(complex)[pair[1]];
 #! >            verts2 := VerticesOfEdges(complex)[pair[2]];
 #! >            if IsEmpty(Intersection(verts1, verts2)) then
-#! >                if not [verts1[1],verts2[1]] in VerticesOfEdges(complex) and
-#! >                   not [verts2[1],verts1[1]] in VerticesOfEdges(complex) then
+#! >                if not Set([verts1[1],verts2[1]]) in VerticesOfEdges(complex) and
+#! >                   not Set([verts2[1],verts1[1]]) in VerticesOfEdges(complex) then
 #! >                	Add(flagPairs,Set([ [ verts1[1], pair[1] ],
 #! > 				[ verts2[1], pair[2] ] ]));
 #! >                fi;
-#! >                if not [verts1[1],verts2[2]] in VerticesOfEdges(complex) and
-#! >                   not [verts2[2],verts1[1]] in VerticesOfEdges(complex) then
+#! >                if not Set([verts1[1],verts2[2]]) in VerticesOfEdges(complex) and
+#! >                   not Set([verts2[2],verts1[1]]) in VerticesOfEdges(complex) then
 #! >                	Add(flagPairs,Set([ [ verts1[1], pair[1] ],
 #! > 				[ verts2[2], pair[2] ] ]));
 #! >                fi;
-#! >                if not [verts1[2],verts2[1]] in VerticesOfEdges(complex) and
-#! >                   not [verts2[1],verts1[2]] in VerticesOfEdges(complex) then
+#! >                if not Set([verts1[2],verts2[1]]) in VerticesOfEdges(complex) and
+#! >                   not Set([verts2[1],verts1[2]]) in VerticesOfEdges(complex) then
 #! >                	Add(flagPairs,Set([ [ verts1[2], pair[1] ],
 #! > 				[ verts2[1], pair[2] ] ]));
 #! >                fi;
-#! >                if not [verts1[2],verts2[2]] in VerticesOfEdges(complex) and
-#! >                   not [verts2[2],verts1[2]] in VerticesOfEdges(complex) then
+#! >                if not Set([verts1[2],verts2[2]]) in VerticesOfEdges(complex) and
+#! >                   not Set([verts2[2],verts1[2]]) in VerticesOfEdges(complex) then
 #! >                	Add(flagPairs,Set([ [ verts1[2], pair[1] ],
 #! > 				[ verts2[2], pair[2] ] ]));
 #! >                fi;

--- a/gap/PolygonalComplexes/modification.gi
+++ b/gap/PolygonalComplexes/modification.gi
@@ -2016,11 +2016,18 @@ InstallMethod( SplitMendableFlagPairs, "for a polygonal complex",
             verts1 := VerticesOfEdges(complex)[pair[1]];
             verts2 := VerticesOfEdges(complex)[pair[2]];
             if Length(Intersection(verts1, verts2)) = 0 then
-                Append( flagPairs, [ 
-                    Set( [ [ verts1[1], pair[1] ], [ verts2[1], pair[2] ] ] ),
-                    Set( [ [ verts1[1], pair[1] ], [ verts2[2], pair[2] ] ] ),
-                    Set( [ [ verts1[2], pair[1] ], [ verts2[1], pair[2] ] ] ),
-                    Set( [ [ verts1[2], pair[1] ], [ verts2[2], pair[2] ] ] )] );
+		if not [verts1[1],verts2[1]] in VerticesOfEdges(complex) and not [verts2[1],verts1[1]] in VerticesOfEdges(complex)  then
+		    Add(flagPairs,Set([ [ verts1[1], pair[1] ], [ verts2[1], pair[2] ] ]));
+		fi;
+		if not [verts1[1],verts2[2]] in VerticesOfEdges(complex) and not [verts2[2],verts1[1]] in VerticesOfEdges(complex) then
+		    Add(flagPairs,Set([ [ verts1[1], pair[1] ], [ verts2[2], pair[2] ] ]));
+		fi;
+		if not [verts1[2],verts2[1]] in VerticesOfEdges(complex) and not [verts2[1],verts1[2]] in VerticesOfEdges(complex)  then
+		    Add(flagPairs,Set([ [ verts1[2], pair[1] ], [ verts2[1], pair[2] ] ]));
+                fi;
+                if not [verts1[2],verts2[2]] in VerticesOfEdges(complex) and not [verts2[2],verts1[2]] in VerticesOfEdges(complex) then
+		    Add(flagPairs,Set([ [ verts1[2], pair[1] ], [ verts2[2], pair[2] ] ]));
+                fi;
             fi;
         od;
 

--- a/gap/PolygonalComplexes/modification.gi
+++ b/gap/PolygonalComplexes/modification.gi
@@ -2016,16 +2016,16 @@ InstallMethod( SplitMendableFlagPairs, "for a polygonal complex",
             verts1 := VerticesOfEdges(complex)[pair[1]];
             verts2 := VerticesOfEdges(complex)[pair[2]];
             if Length(Intersection(verts1, verts2)) = 0 then
-		if not [verts1[1],verts2[1]] in VerticesOfEdges(complex) and not [verts2[1],verts1[1]] in VerticesOfEdges(complex)  then
+		if not Set([verts1[1],verts2[1]]) in VerticesOfEdges(complex) and not Set([verts2[1],verts1[1]]) in VerticesOfEdges(complex)  then
 		    Add(flagPairs,Set([ [ verts1[1], pair[1] ], [ verts2[1], pair[2] ] ]));
 		fi;
-		if not [verts1[1],verts2[2]] in VerticesOfEdges(complex) and not [verts2[2],verts1[1]] in VerticesOfEdges(complex) then
+		if not Set([verts1[1],verts2[2]]) in VerticesOfEdges(complex) and not Set([verts2[2],verts1[1]]) in VerticesOfEdges(complex) then
 		    Add(flagPairs,Set([ [ verts1[1], pair[1] ], [ verts2[2], pair[2] ] ]));
 		fi;
-		if not [verts1[2],verts2[1]] in VerticesOfEdges(complex) and not [verts2[1],verts1[2]] in VerticesOfEdges(complex)  then
+		if not Set([verts1[2],verts2[1]]) in VerticesOfEdges(complex) and not Set([verts2[1],verts1[2]]) in VerticesOfEdges(complex)  then
 		    Add(flagPairs,Set([ [ verts1[2], pair[1] ], [ verts2[1], pair[2] ] ]));
                 fi;
-                if not [verts1[2],verts2[2]] in VerticesOfEdges(complex) and not [verts2[2],verts1[2]] in VerticesOfEdges(complex) then
+                if not Set([verts1[2],verts2[2]]) in VerticesOfEdges(complex) and not Set([verts2[2],verts1[2]]) in VerticesOfEdges(complex) then
 		    Add(flagPairs,Set([ [ verts1[2], pair[1] ], [ verts2[2], pair[2] ] ]));
                 fi;
             fi;


### PR DESCRIPTION
The method has returned flag pairs that aren't split-mendable. I added a query that checks whether there is an edge which has the first vertex and the second vertex of the pair as vertices.