### PR TITLE
Bug fix in `__SIMPLICIAL_ComputeNewVertexEdgePaths`

### DIFF
--- a/gap/PolygonalComplexes/modification.gi
+++ b/gap/PolygonalComplexes/modification.gi
@@ -309,7 +309,7 @@ BindGlobal( "__SIMPLICIAL_ComputeNewVertexEdgePaths",
                             Add(extOld, PathAsList(vePath)[i]);
 
                             Add(newPaths, [ extNew, extOld ]);
-			
+			    new := new + 1; 
 			    used:=true;
                         fi;
                     od;


### PR DESCRIPTION
This bug causes a problem in the labelling informtion of `SplitVertexEdgePath`.