### PR TITLE
Increase rank of IsIsomorphic for nauty

### DIFF
--- a/gap/PolygonalComplexes/graphs.gi
+++ b/gap/PolygonalComplexes/graphs.gi
@@ -315,8 +315,9 @@ fi;
 if IsPackageMarkedForLoading("NautyTracesInterface", ">=0") then
     InstallMethod( IsIsomorphic, 
         "for two twisted polygonal complexes", 
-        [IsTwistedPolygonalComplex, IsTwistedPolygonalComplex],
+        [IsTwistedPolygonalComplex, IsTwistedPolygonalComplex],5,
         function(complex1, complex2)
+       
 	    if IsSimplicialSurface(complex1) and IsSimplicialSurface(complex2) and CounterOfButterflies(complex1)<>CounterOfButterflies(complex2) then
                 return false;
             fi;


### PR DESCRIPTION
When nauty and grape were loaded, the IsIsomorphic method was used for grape because it has a higher rank. Since nauty is the better choice because it is faster, we increased the rank.