### PR TITLE
Rename of some methods

### DIFF
--- a/doc/ExampleApplications.xml
+++ b/doc/ExampleApplications.xml
@@ -86,14 +86,14 @@ simplicial surface (17 vertices, 45 edges, and 30 faces)
         We can already read of the number of vertices, edges, and faces.
         Some other elementary properties are orientability 
         (<K>IsOrientable</K>, <Ref Subsect="IsOrientable"/>),
-        connectivity (<K>IsConnected</K>, <Ref Subsect="IsConnected"/>),
+        connectivity (<K>IsConnectedComplex</K>, <Ref Subsect="IsConnected"/>),
         closedness (<K>IsClosedSurface</K>, <Ref Subsect="IsClosedSurface"/>),
         and the Euler-characteristic (<K>EulerCharacteristic</K>,
         <Ref Subsect="EulerCharacteristic"/>).
 <Example>
 gap&gt; IsOrientable(newSurf);
 true
-gap&gt; IsConnected(newSurf);
+gap&gt; IsConnectedSurface(newSurf);
 true
 gap&gt; IsClosedSurface(newSurf);
 true

--- a/doc/ExampleApplications.xml
+++ b/doc/ExampleApplications.xml
@@ -85,13 +85,13 @@ simplicial surface (17 vertices, 45 edges, and 30 faces)
 </Example>
         We can already read of the number of vertices, edges, and faces.
         Some other elementary properties are orientability 
-        (<K>IsOrientable</K>, <Ref Subsect="IsOrientable"/>),
+        (<K>IsOrientablComplex</K>, <Ref Subsect="IsOrientable"/>),
         connectivity (<K>IsConnectedComplex</K>, <Ref Subsect="IsConnected"/>),
-        closedness (<K>IsClosedSurface</K>, <Ref Subsect="IsClosedSurface"/>),
+        closedness (<K>IsClosedComplex</K>, <Ref Subsect="IsClosedSurface"/>),
         and the Euler-characteristic (<K>EulerCharacteristic</K>,
         <Ref Subsect="EulerCharacteristic"/>).
 <Example>
-gap&gt; IsOrientable(newSurf);
+gap&gt; IsOrientableSurface(newSurf);
 true
 gap&gt; IsConnectedSurface(newSurf);
 true

--- a/doc/Introduction.xml
+++ b/doc/Introduction.xml
@@ -158,7 +158,7 @@ gap&gt; EulerCharacteristic(surface);
 <Example>
 gap&gt; IsClosedSurface(surface);
 true
-gap&gt; IsConnected(surface);
+gap&gt; IsConnectedSurface(surface);
 true
 gap&gt; IsOrientable(surface);
 true

--- a/doc/Introduction.xml
+++ b/doc/Introduction.xml
@@ -160,7 +160,7 @@ gap&gt; IsClosedSurface(surface);
 true
 gap&gt; IsConnectedSurface(surface);
 true
-gap&gt; IsOrientable(surface);
+gap&gt; IsOrientableSurface(surface);
 true
 </Example>
         We can also compute more complicated properties like the 
@@ -269,7 +269,7 @@ gap&gt; VerticesOfFaces(surf);
 <Example>
 gap&gt; moebius := SimplicialSurfaceByVerticesInFaces(
 &gt;                            [[1,2,3],[2,3,4],[3,4,5],[4,5,1],[5,2,1]]);;
-gap&gt; IsOrientable(moebius);
+gap&gt; IsOrientableSurface(moebius);
 false
 </Example>
 <!-- TODO can you avoid the colour loss? Can't we just use the gap-prompt as a left fixture -->

--- a/gap/ColouredComplexes/edgeColouring.gi
+++ b/gap/ColouredComplexes/edgeColouring.gi
@@ -480,7 +480,7 @@ InstallMethod( DisplayInformationEdgeColoured,
 
         # Special information for edge coloured polygonal surfaces
         if IsPolygonalSurface(PolygonalComplex(colComp)) then # more information
-            if IsClosedSurface(complex) then
+            if IsClosedComplex(complex) then
                 PrintTo(out, "closed, ");
             fi;
             

--- a/gap/ColouredComplexes/edgeColouring.gi
+++ b/gap/ColouredComplexes/edgeColouring.gi
@@ -490,7 +490,7 @@ InstallMethod( DisplayInformationEdgeColoured,
                 PrintTo(out, "non-orientable, ");
             fi;
 
-            if IsConnected(complex) then
+            if IsConnectedSurface(complex) then
                 PrintTo(out, "Euler-characteristic ", EulerCharacteristic(complex) );
             else
                 PrintTo(out,  NumberOfConnectedComponents(complex), " connected components" );

--- a/gap/ColouredComplexes/edgeColouring.gi
+++ b/gap/ColouredComplexes/edgeColouring.gi
@@ -484,7 +484,7 @@ InstallMethod( DisplayInformationEdgeColoured,
                 PrintTo(out, "closed, ");
             fi;
             
-            if IsOrientable(complex) then
+            if IsOrientableComplex(complex) then
                 PrintTo(out, "orientable, ");
             else
                 PrintTo(out, "non-orientable, ");

--- a/gap/ColouredComplexes/variColouring_images.gd
+++ b/gap/ColouredComplexes/variColouring_images.gd
@@ -57,7 +57,7 @@ disk := PolygonalSurfaceByDownwardIncidence(
         [4,11],[4,12],[5,6],[6,7],[7,8],[8,9],[9,10],[10,11],[11,12],[5,12]],
     [[13,6,5],[14,7,2,6],[15,8,7],[5,1,12,20],[2,3,4,1],
         [8,16,9,3],[12,11,19],[4,10,18,11],[9,17,10]] );;
-IsClosedSurface(disk);
+IsClosedComplex(disk);
 #! false
 colDisk := EdgeColouredPolygonalComplex(disk, 
     [[13,15,17,19],,[5,2,8,18],[14,12,4,9],[20,7,3,10],[6,1,11,16]] );;

--- a/gap/Library/library.gd
+++ b/gap/Library/library.gd
@@ -188,7 +188,7 @@
 #! restricted:
 #! @BeginExampleSession
 #! gap> plat := AllPolygonalComplexes( [4,8], 
-#! >               EulerCharacteristic, 2, IsConnectedComplex, IsClosedSurface );;
+#! >               EulerCharacteristic, 2, IsConnectedComplex, IsClosedComplex );;
 #! gap> Size(plat);
 #! 2
 #! @EndExampleSession

--- a/gap/Library/library.gd
+++ b/gap/Library/library.gd
@@ -94,7 +94,7 @@
 #! Obviously, we can use functions defined by this package. For example,
 #! the following command returns all predefined tori:
 #! @BeginExampleSession
-#! gap> AllPolygonalComplexes( IsConnected, true, 
+#! gap> AllPolygonalComplexes( IsConnectedComplex, true, 
 #! >            IsOrientable, true, EulerCharacteristic, 0 );
 #! [ simplicial surface (3 vertices, 9 edges, and 6 faces), 
 #!   simplicial surface (9 vertices, 27 edges, and 18 faces), 
@@ -103,7 +103,7 @@
 #! Since it is tedious to always write <K>true</K>, there is a shortcut
 #! implemented that interprets "missing" results as <K>true</K>: 
 #! @BeginExampleSession
-#! gap> AllPolygonalComplexes( IsConnected, IsOrientable, EulerCharacteristic, 0 );
+#! gap> AllPolygonalComplexes( IsConnectedComplex, IsOrientable, EulerCharacteristic, 0 );
 #! [ simplicial surface (3 vertices, 9 edges, and 6 faces), 
 #!   simplicial surface (9 vertices, 27 edges, and 18 faces), 
 #!   simplicial surface (4 vertices, 12 edges, and 8 faces) ]
@@ -151,7 +151,7 @@
 #! >    end;;
 #! gap> plat := AllPolygonalComplexes( IsPolygonalSurface, true,
 #! >      EulerCharacteristic, 2, DegreeRegular, true,
-#! >      IsConnected, true, IsClosedSurface, true);;
+#! >      IsConnectedSurface, true, IsClosedSurface, true);;
 #! gap> Size(plat);
 #! 5
 #! @EndExampleSession
@@ -171,7 +171,7 @@
 #! as follows:
 #! @BeginExampleSession
 #! gap> plat := AllPolygonalSurfaces( EulerCharacteristic, 2, DegreeRegular,
-#! >      IsConnected, IsClosedSurface );;
+#! >      IsConnectedSurface, IsClosedSurface );;
 #! gap> Size(plat);
 #! 5
 #! @EndExampleSession
@@ -179,7 +179,7 @@
 #! command may be used:
 #! @BeginExampleSession
 #! gap> plat := AllSimplicialSurfaces( EulerCharacteristic, 2, DegreeRegular,
-#! >      IsConnected, IsClosedSurface );;
+#! >      IsConnectedSurface, IsClosedSurface );;
 #! gap> Size(plat);
 #! 3
 #! @EndExampleSession
@@ -188,7 +188,7 @@
 #! restricted:
 #! @BeginExampleSession
 #! gap> plat := AllPolygonalComplexes( [4,8], 
-#! >               EulerCharacteristic, 2, IsConnected, IsClosedSurface );;
+#! >               EulerCharacteristic, 2, IsConnectedComplex, IsClosedSurface );;
 #! gap> Size(plat);
 #! 2
 #! @EndExampleSession

--- a/gap/Library/library.gd
+++ b/gap/Library/library.gd
@@ -95,7 +95,7 @@
 #! the following command returns all predefined tori:
 #! @BeginExampleSession
 #! gap> AllPolygonalComplexes( IsConnectedComplex, true, 
-#! >            IsOrientable, true, EulerCharacteristic, 0 );
+#! >            IsOrientableComplex, true, EulerCharacteristic, 0 );
 #! [ simplicial surface (3 vertices, 9 edges, and 6 faces), 
 #!   simplicial surface (9 vertices, 27 edges, and 18 faces), 
 #!   simplicial surface (4 vertices, 12 edges, and 8 faces) ]
@@ -103,7 +103,7 @@
 #! Since it is tedious to always write <K>true</K>, there is a shortcut
 #! implemented that interprets "missing" results as <K>true</K>: 
 #! @BeginExampleSession
-#! gap> AllPolygonalComplexes( IsConnectedComplex, IsOrientable, EulerCharacteristic, 0 );
+#! gap> AllPolygonalComplexes( IsConnectedComplex, IsOrientableComplex, EulerCharacteristic, 0 );
 #! [ simplicial surface (3 vertices, 9 edges, and 6 faces), 
 #!   simplicial surface (9 vertices, 27 edges, and 18 faces), 
 #!   simplicial surface (4 vertices, 12 edges, and 8 faces) ]
@@ -120,7 +120,7 @@
 #! >        return Length(intersect) > 0;
 #! > end;
 #! function( surface ) ... end
-#! gap> AllSimplicialSurfaces(IsOrientable, false, HasCentralVertex);
+#! gap> AllSimplicialSurfaces(IsOrientableSurface, false, HasCentralVertex);
 #! [ simplicial surface (3 vertices, 6 edges, and 3 faces), 
 #!   simplicial surface (3 vertices, 6 edges, and 4 faces), 
 #!   simplicial surface (4 vertices, 12 edges, and 8 faces) ]
@@ -136,7 +136,7 @@
 #! the second argument is either the result of that function or a list of
 #! accepted results. For example
 #! @BeginLog
-#! gap> AllTwistedPolygonalComplexes( NumberOfVertices, [10,12], IsOrientable, false );
+#! gap> AllTwistedPolygonalComplexes( NumberOfVertices, [10,12], IsOrientableComplex, false );
 #! @EndLog
 #! returns all non-orientable twisted polygonal complexes with 10 or 12 vertices from
 #! the library.

--- a/gap/Paths/connectivity.gi
+++ b/gap/Paths/connectivity.gi
@@ -2,7 +2,7 @@
 ##
 ##  SimplicialSurface package
 ##
-##  Copyright 2012-2016
+##  Copyright 2012-2025
 ##    Markus Baumeister, RWTH Aachen University
 ##    Alice Niemeyer, RWTH Aachen University 
 ##
@@ -82,7 +82,7 @@ BindGlobal( "__SIMPLICIAL_AbstractConnectedComponent",
 ##
 ## general connectivity
 ##
-InstallMethod( IsConnected, "for a twisted polygonal complex", [IsTwistedPolygonalComplex], 
+InstallMethod( IsConnectedComplex, "for a twisted polygonal complex", [IsTwistedPolygonalComplex], 
     function(complex)
 	local component;
 
@@ -96,7 +96,7 @@ InstallMethod( IsConnected, "for a twisted polygonal complex", [IsTwistedPolygon
         return Length( component ) = NumberOfFaces(complex);
     end
 );
-InstallImmediateMethod( IsConnected, 
+InstallImmediateMethod( IsConnectedComplex, 
     IsTwistedPolygonalComplex and HasConnectedComponentsAttributeOfComplex,0, 
     function(complex)
 	local components;
@@ -106,7 +106,13 @@ InstallImmediateMethod( IsConnected,
     end
 );
 
-InstallMethod( IsStronglyConnected, "for a twisted polygonal complex", [IsTwistedPolygonalComplex],
+InstallMethod( IsConnectedSurface, "for a surface", [IsPolygonalSurface], 
+    function(surf)
+        return IsConnectedComplex(surf);
+    end
+);
+
+InstallMethod( IsStronglyConnectedComplex, "for a twisted polygonal complex", [IsTwistedPolygonalComplex],
     function(complex)
 	local component;
 
@@ -120,7 +126,7 @@ InstallMethod( IsStronglyConnected, "for a twisted polygonal complex", [IsTwiste
         return Length( component ) = NumberOfFaces(complex);
     end
 );
-InstallImmediateMethod( IsStronglyConnected, 
+InstallImmediateMethod( IsStronglyConnectedComplex, 
     IsTwistedPolygonalComplex and HasStronglyConnectedComponentsAttributeOfComplex, 0, 
     function(complex)
 	local components;
@@ -130,7 +136,7 @@ InstallImmediateMethod( IsStronglyConnected,
     end
 );
 
-InstallImmediateMethod( IsStronglyConnected, IsTwistedPolygonalComplex and 
+InstallImmediateMethod( IsStronglyConnectedComplex, IsTwistedPolygonalComplex and 
     HasConnectedComponentsAttributeOfComplex, 0,
     function(complex)
         local components;
@@ -143,13 +149,19 @@ InstallImmediateMethod( IsStronglyConnected, IsTwistedPolygonalComplex and
     end
 );
 
-InstallImmediateMethod( IsStronglyConnected, 
-    IsTwistedPolygonalComplex and HasIsConnected, 0,
+InstallImmediateMethod( IsStronglyConnectedComplex, 
+    IsTwistedPolygonalComplex and HasIsConnectedComplex, 0,
     function(complex)
-        if not IsConnected(complex) then
+        if not IsConnectedComplex(complex) then
             return false;
         fi;
         TryNextMethod();
+    end
+);
+
+InstallMethod( IsStronglyConnectedSurface, "for a surface", [IsPolygonalSurface],
+    function(surf)
+        return IsStronglyConnectedComplex(surf);
     end
 );
 
@@ -166,12 +178,12 @@ InstallMethod( ConnectedComponentOfFaceNC, "for a twisted polygonal complex",
 
 	subsurf := SubcomplexByFacesNC( complex, comp);
 	# this component is connected by construction, so we set the property
-	SetIsConnected( subsurf, true );
+	SetIsConnectedComplex( subsurf, true );
 	return subsurf;
     end
 );
 InstallMethod( ConnectedComponentOfFaceNC, "for a twisted polygonal complex",
-    [IsTwistedPolygonalComplex and IsConnected, IsPosInt],
+    [IsTwistedPolygonalComplex and IsConnectedComplex, IsPosInt],
     function(complex, f)
 	return complex; # A connected surface has only one connected component
     end
@@ -197,12 +209,12 @@ InstallMethod( StronglyConnectedComponentOfFaceNC, "for a twisted polygonal comp
 
 	subsurf := SubcomplexByFacesNC( complex, comp);
 	# this component is strongly connected by construction, so we set the property
-	SetIsStronglyConnected( subsurf, true );
+	SetIsStronglyConnectedComplex( subsurf, true );
 	return subsurf;
     end
 );
 InstallMethod( StronglyConnectedComponentOfFaceNC, "for a twisted polygonal complex",
-    [IsTwistedPolygonalComplex and IsStronglyConnected, IsPosInt],
+    [IsTwistedPolygonalComplex and IsStronglyConnectedComplex, IsPosInt],
     function(complex, face)
 	return complex; # A strongly connected surface has only one strongly connected component
     end
@@ -270,7 +282,7 @@ InstallMethod( ConnectedComponentsAttributeOfComplex,
     end
 );
 InstallImmediateMethod( ConnectedComponentsAttributeOfComplex,
-    IsTwistedPolygonalComplex and IsConnected, 0, 
+    IsTwistedPolygonalComplex and IsConnectedComplex, 0, 
     function(complex)
 	return [complex];
     end
@@ -295,7 +307,7 @@ InstallMethod( StronglyConnectedComponentsAttributeOfComplex,
     end
 );
 InstallImmediateMethod( StronglyConnectedComponentsAttributeOfComplex,
-    IsTwistedPolygonalComplex and IsStronglyConnected, 0,
+    IsTwistedPolygonalComplex and IsStronglyConnectedComplex, 0,
     function(complex)
         return [complex];
     end
@@ -306,7 +318,7 @@ InstallImmediateMethod( StronglyConnectedComponentsAttributeOfComplex,
 ## After implementing connectivity and strong connectivity for themselves, we
 ## also want to work with the connection between them. We start with the
 ## direction "strongly connected"->"connected"
-InstallImmediateMethod( IsConnected, 
+InstallImmediateMethod( IsConnectedComplex, 
     IsTwistedPolygonalComplex and HasStronglyConnectedComponentsAttributeOfComplex, 0, 
     function( complex )
         local components;
@@ -401,7 +413,7 @@ InstallMethod( StronglyConnectedComponentsAttributeOfComplex,
     end
 );
 InstallImmediateMethod( StronglyConnectedComponentsAttributeOfComplex,
-    IsTwistedPolygonalSurface and IsConnected, 0, 
+    IsTwistedPolygonalSurface and IsConnectedComplex, 0, 
     function(surf)
         return [surf];
     end

--- a/gap/Paths/orientability.gi
+++ b/gap/Paths/orientability.gi
@@ -166,9 +166,9 @@ AddPropertyIncidence( SIMPLICIAL_ATTRIBUTE_SCHEDULER,
 ##
 InstallImmediateMethod( Orientation, 
     "for a polygonal complex without edge ramifications with known orientation",
-    IsPolygonalComplex and IsNotEdgeRamified and HasIsOrientable, 0,
+    IsPolygonalComplex and IsNotEdgeRamified and HasIsOrientableComplex, 0,
     function(ramSurf)
-        if not IsOrientable(ramSurf) then
+        if not IsOrientableComplex(ramSurf) then
             return fail;
         fi;
         TryNextMethod();
@@ -178,7 +178,7 @@ InstallImmediateMethod( Orientation,
 ##
 ##  Now we write the method to only check if an orientation exists
 ##
-InstallImmediateMethod( IsOrientable,
+InstallImmediateMethod( IsOrientableComplex,
     "for a polygonal complex without edge ramifications with Orientation",
     IsPolygonalComplex and IsNotEdgeRamified and HasOrientation, 0,
     function(ramSurf)
@@ -188,7 +188,7 @@ InstallImmediateMethod( IsOrientable,
 
 ## If we can't compute IsOrientable any other way, we try computing a global
 ## orientation first
-InstallMethod( IsOrientable,
+InstallMethod( IsOrientableComplex,
     "for a polygonal complex without edge ramifications",
     [IsPolygonalComplex and IsNotEdgeRamified],
     function(ramSurf)
@@ -196,12 +196,12 @@ InstallMethod( IsOrientable,
             TryNextMethod();
         fi;
         Orientation(ramSurf);
-        return IsOrientable(ramSurf);
+        return IsOrientableComplex(ramSurf);
     end
 );
 
 ## global orientation computation for twisted polygonal complexes
-InstallMethod( IsOrientable,
+InstallMethod( IsOrientableComplex,
     "for a twisted polygonal complex",
     [IsTwistedPolygonalComplex and IsNotEdgeRamified],
     function(complex)
@@ -261,6 +261,14 @@ InstallMethod( IsOrientable,
             od;
         od;
         return true;
+    end
+);
+
+InstallMethod( IsOrientableSurface,
+    "for a polygonal surface",
+    [IsPolygonalSurface],
+    function(surf)
+        return IsOrientableComplex(surf);
     end
 );
 

--- a/gap/Paths/paths.gd
+++ b/gap/Paths/paths.gd
@@ -1786,7 +1786,7 @@ DeclareAttribute( "GeodesicFlagCycle", IsEdgeFacePath and IsClosedGeodesicPath )
 #! <Ref Sect="Section_Graphs_Incidence"/>) is 
 #! connected.
 #! @ExampleSession
-#! gap> IsConnected( butterfly );
+#! gap> IsConnectedComplex( butterfly );
 #! true
 #! @EndExampleSession
 #! But in several situations it is convenient to regard this
@@ -1810,7 +1810,7 @@ DeclareAttribute( "GeodesicFlagCycle", IsEdgeFacePath and IsClosedGeodesicPath )
 #! For a polygonal surface <E>strong connectivity</E> is equivalent to
 #! <E>connectivity</E> since there are no ramified vertices.
 #! @ExampleSession
-#! gap> IsStronglyConnected( butterfly );
+#! gap> IsStronglyConnectedComplex( butterfly );
 #! false
 #! @EndExampleSession
 #!
@@ -1818,15 +1818,13 @@ DeclareAttribute( "GeodesicFlagCycle", IsEdgeFacePath and IsClosedGeodesicPath )
 #! @BeginGroup IsConnected
 #! @Description
 #! Check whether the given twisted polygonal complex is connected. A twisted
-#! polygonal complex
-#! is connected if and only if its incidence graph (compare section 
-#! <Ref Sect="Section_Graphs_Incidence"/>) is 
-#! connected.
+#! polygonal complex is connected if and only if its incidence graph 
+#! (compare section <Ref Sect="Section_Graphs_Incidence"/>) is connected.
 #!
-#! For example, consider the ramified simplicial surface from the start of 
+#! For example, consider the triangular complex from the start of 
 #! section <Ref Sect="Section_Paths_Connectivity"/>:
  
-#!  <Alt Only="HTML">
+#! <Alt Only="HTML">
 #! &lt;br>&lt;img src='./images/_Wrapper_paths-17-1.svg'> &lt;/img> &lt;br>
 #! </Alt>
 #! <Alt Only = "LaTeX">
@@ -1836,14 +1834,16 @@ DeclareAttribute( "GeodesicFlagCycle", IsEdgeFacePath and IsClosedGeodesicPath )
 #! </Alt>
 #! <Alt Only = "Text">
 #! Image omitted in terminal text
-            #! </Alt>
+#! </Alt>
 #! @ExampleSession
-#! gap> IsConnected( butterfly );
+#! gap> IsConnectedComplex( butterfly );
 #! true
 #! @EndExampleSession
 #! 
 #! @Arguments complex
-DeclareProperty( "IsConnected", IsTwistedPolygonalComplex );
+DeclareProperty( "IsConnectedComplex", IsTwistedPolygonalComplex );
+#! @Arguments surface
+DeclareProperty( "IsConnectedSurface", IsPolygonalSurface );
 #! @EndGroup
 
 #! @BeginGroup ConnectedComponents
@@ -1870,7 +1870,7 @@ DeclareProperty( "IsConnected", IsTwistedPolygonalComplex );
 #! </Alt>
 #! <Alt Only = "Text">
 #! Image omitted in terminal text
-            #! </Alt>
+#! </Alt>
 #! @ExampleSession
 #! gap> comp := ConnectedComponents( butterfly );;
 #! gap> Size(comp);
@@ -1903,15 +1903,13 @@ DeclareOperation( "ConnectedComponentOfFaceNC", [IsTwistedPolygonalComplex, IsPo
 #! @BeginGroup IsStronglyConnected
 #! @Description
 #! Check whether the given twisted polygonal complex is strongly connected. 
-#! A twisted polygonal 
-#! complex
-#! is strongly connected if and only if one of the following equivalent 
-#! conditions hold:
-#! * It is still connected after removal of all vertices. 
+#! A twisted polygonal complex is strongly connected if and only if one of
+#! the following equivalent conditions hold:
+#! * It is still connected after removing an arbitary vertex. 
 #! * For each pair of faces there is an edge-face-path (compare section 
 #!   <Ref Sect="Section_Access_OrderedVertexAccess"/>) that connects them.
 #!
-#! For example, consider the ramified simplicial surface from the start of 
+#! For example, consider the triangular complex from the start of 
 #! section <Ref Sect="Section_Paths_Connectivity"/>:
  
 #!  <Alt Only="HTML">
@@ -1926,12 +1924,14 @@ DeclareOperation( "ConnectedComponentOfFaceNC", [IsTwistedPolygonalComplex, IsPo
 #! Image omitted in terminal text
             #! </Alt>
 #! @ExampleSession
-#! gap> IsStronglyConnected( butterfly );
+#! gap> IsStronglyConnectedComplex( butterfly );
 #! false
 #! @EndExampleSession
 #! 
 #! @Arguments complex
-DeclareProperty( "IsStronglyConnected", IsTwistedPolygonalComplex );
+DeclareProperty( "IsStronglyConnectedComplex", IsTwistedPolygonalComplex );
+#! @Arguments surf
+DeclareProperty( "IsStronglyConnectedSurface", IsPolygonalSurface );
 #! @EndGroup
 
 

--- a/gap/Paths/paths.gd
+++ b/gap/Paths/paths.gd
@@ -2068,7 +2068,7 @@ DeclareAttribute( "NumberOfStronglyConnectedComponents", IsTwistedPolygonalCompl
 #! gap> surface := PolygonalSurfaceByDownwardIncidence(
 #! > [,[3,5],,,,[3,7],,[3,11],,[7,11],,[5,13],,[7,13],[11,13]],
 #! > [ [2,6,12,14],,, [6,8,10],,,,, [10,14,15] ]);;
-#! gap> IsOrientable(surface);
+#! gap> IsOrientableSurface(surface);
 #! true
 #! @EndExampleSession
 #!
@@ -2130,20 +2130,22 @@ DeclareAttribute( "NumberOfStronglyConnectedComponents", IsTwistedPolygonalCompl
 #! </Alt>
 #! <Alt Only = "Text">
 #! Image omitted in terminal text
-            #! </Alt>
+#! </Alt>
 #! @ExampleSession
-#! gap> IsOrientable( surface );
+#! gap> IsOrientableSurface( surface );
 #! true
 #! @EndExampleSession
 #! An example for a non orientable surface is the Möbius-strip:
 #! @BeginExampleSession
 #! gap> moebius := SimplicialSurfaceByVerticesInFaces( 
 #! > [[1,2,3],[2,3,4],[3, 4,5],[4,5,1],[5,2,1] ]);;
-#! gap> IsOrientable(moebius); 
+#! gap> IsOrientableSurface(moebius); 
 #! false
 #! @EndExampleSession
-#! @Arguments ramSurf
-DeclareProperty( "IsOrientable", IsTwistedPolygonalComplex and IsNotEdgeRamified );
+#! @Arguments complex
+DeclareProperty( "IsOrientableComplex", IsTwistedPolygonalComplex and IsNotEdgeRamified );
+#! @Arguments surf
+DeclareProperty( "IsOrientableSurface", IsPolygonalSurface );
 #! @EndGroup
 
 #! @BeginGroup Orientation

--- a/gap/PolygonalComplexes/discs.gd
+++ b/gap/PolygonalComplexes/discs.gd
@@ -44,7 +44,7 @@
 #! >    [ 3, 9, 10 ], [ 4, 10, 11 ], [ 11, 12, 16 ], [ 12, 13, 17 ],
 #! >    [ 5, 6, 13 ] ] );
 #! simplicial surface (8 vertices, 17 edges, and 10 faces)
-#! gap> IsConnected(disc);
+#! gap> IsConnectedSurface(disc);
 #! true
 #! gap> EulerCharacteristic(disc);
 #! 1
@@ -74,7 +74,7 @@ DeclareOperation( "IsEssentialDisc", [IsTwistedPolygonalComplex] );
 #! > [ [1, 2, 3], [1, 4, 5], [6, 7, 14], [2, 7, 8], [8, 9, 15],
 #! > [3, 9, 10], [10, 11, 16], [4, 11, 12], [12, 13, 17], [5, 6, 13] ]);
 #! simplicial surface (8 vertices, 17 edges, and 10 faces)
-#! gap> IsConnected(surface);
+#! gap> IsConnectedSurface(surface);
 #! true
 #! gap> EulerCharacteristic(surface);
 #! 1

--- a/gap/PolygonalComplexes/discs.gi
+++ b/gap/PolygonalComplexes/discs.gi
@@ -20,7 +20,7 @@ InstallMethod( IsEssentialDisc,
 
            if not IsSimplicialSurface(disc) then return false; fi;
 
-           if not IsConnected(disc) then return false; fi;
+           if not IsConnectedSurface(disc) then return false; fi;
            if EulerCharacteristic(disc)<>1 then return false; fi;
 
            bound := BoundaryVertices(disc);

--- a/gap/PolygonalComplexes/drawing.gi
+++ b/gap/PolygonalComplexes/drawing.gi
@@ -782,7 +782,7 @@ BindGlobal( "__SIMPLICIAL_PrintRecordDrawFace",
         Append(res, "\\fill[");
         #TODO this does not make sense without mirror/rotation edges -> revisit this problem then
         # Determine if the swap colour is used
-#        if IsOrientable(surface) and printRecord!.faceVertices[face][2][1]^OrientationByVerticesAsPerm(surface)[face] = printRecord!.faceVertices[face][1][1] then
+#        if IsOrientableComplex(surface) and printRecord!.faceVertices[face][2][1]^OrientationByVerticesAsPerm(surface)[face] = printRecord!.faceVertices[face][1][1] then
 #            Append(res, "faceSwap");
 #        else
             Append(res, "face");

--- a/gap/PolygonalComplexes/main.gi
+++ b/gap/PolygonalComplexes/main.gi
@@ -405,7 +405,7 @@ InstallMethod( DisplayInformation, "for a twisted polygonal complex",
         PrintTo(out, __SIMPLICIAL_PolygonalComplexName(complex, true) );
         if IsPolygonalSurface(complex) then # more information
             PrintTo(out,  " (" );
-            if IsClosedSurface(complex) then
+            if IsClosedComplex(complex) then
                 PrintTo(out, "closed, ");
             fi;
             

--- a/gap/PolygonalComplexes/main.gi
+++ b/gap/PolygonalComplexes/main.gi
@@ -409,7 +409,7 @@ InstallMethod( DisplayInformation, "for a twisted polygonal complex",
                 PrintTo(out, "closed, ");
             fi;
             
-            if IsOrientable(complex) then
+            if IsOrientableComplex(complex) then
                 PrintTo(out, "orientable, ");
             else
                 PrintTo(out, "non-orientable, ");

--- a/gap/PolygonalComplexes/main.gi
+++ b/gap/PolygonalComplexes/main.gi
@@ -415,7 +415,7 @@ InstallMethod( DisplayInformation, "for a twisted polygonal complex",
                 PrintTo(out, "non-orientable, ");
             fi;
 
-            if IsConnected(complex) then
+            if IsConnectedComplex(complex) then
                 PrintTo(out, "Euler-characteristic ", EulerCharacteristic(complex) );
             else
                 PrintTo(out,  NumberOfConnectedComponents(complex), " connected components" );

--- a/gap/PolygonalComplexes/properties.gd
+++ b/gap/PolygonalComplexes/properties.gd
@@ -118,8 +118,7 @@ DeclareAttribute( "EulerCharacteristic", IsTwistedPolygonalComplex );
 #! Check whether the given twisted polygonal complex without edge ramifications is 
 #! <E>closed</E>.
 #! A twisted polygonal complex without edge ramifications is closed if every edge is 
-#! incident to <E>exactly</E> 
-#! two
+#! incident to <E>exactly</E> two
 #! faces (whereas the absence of edge ramifications only means that
 #! every edge is incident to <E>at most</E> two faces).
 #!
@@ -161,12 +160,14 @@ DeclareAttribute( "EulerCharacteristic", IsTwistedPolygonalComplex );
 #! Image omitted in terminal text
             #! </Alt>
 #! @ExampleSession
-#! gap> IsClosedSurface(triforce);
+#! gap> IsClosedComplex(triforce);
 #! false
 #! @EndExampleSession
 #!
-#! @Arguments ramSurf
-DeclareProperty( "IsClosedSurface", IsTwistedPolygonalComplex and IsNotEdgeRamified );
+#! @Arguments complex
+DeclareProperty( "IsClosedComplex", IsTwistedPolygonalComplex and IsNotEdgeRamified );
+#! @Arguments surf
+DeclareProperty( "IsClosedSurface", IsPolygonalSurface );
 ## We can't use IsClosed since this is blocked by the orb-package
 #! @EndGroup
 

--- a/gap/PolygonalComplexes/properties.gi
+++ b/gap/PolygonalComplexes/properties.gi
@@ -22,7 +22,7 @@ InstallMethod( EulerCharacteristic, "for a twisted polygonal complex",
     end
 );
 
-InstallMethod( IsClosedSurface, "for a polygonal complex without edge ramifications",
+InstallMethod( IsClosedComplex, "for a polygonal complex without edge ramifications",
     [IsPolygonalComplex and IsNotEdgeRamified],
     function( ramSurf )
         local faces;
@@ -35,7 +35,7 @@ InstallMethod( IsClosedSurface, "for a polygonal complex without edge ramificati
         return true;
     end
 );
-InstallMethod( IsClosedSurface, "for a twisted polygonal complex without edge ramifications",
+InstallMethod( IsClosedComplex, "for a twisted polygonal complex without edge ramifications",
     [IsTwistedPolygonalComplex and IsNotEdgeRamified],
     function( ramSurf )
         local edgeClass;
@@ -48,13 +48,20 @@ InstallMethod( IsClosedSurface, "for a twisted polygonal complex without edge ra
         return true;
     end
 );
-InstallOtherMethod( IsClosedSurface, "for a twisted polygonal complex",
+InstallOtherMethod( IsClosedComplex, "for a twisted polygonal complex",
     [IsTwistedPolygonalComplex],
     function(complex)
         if not IsNotEdgeRamified(complex) then
-            Error("IsClosedSurface: Given twisted polygonal complex complex contains ramified edges.");
+            Error("IsClosedComplex: Given twisted polygonal complex complex contains ramified edges.");
         fi;
-        return IsClosedSurface(complex); # Call the function above
+        return IsClosedComplex(complex); # Call the function above
+    end
+);
+
+InstallMethod( IsClosedSurface, "for a polygonal surface",
+    [IsPolygonalSurface],
+    function( surf )
+        return IsClosedComplex(surf);
     end
 );
 
@@ -62,7 +69,7 @@ InstallMethod( IsMultiTetrahedralSphere, "for a twisted polygonal complex",
     [IsTwistedPolygonalComplex],
     function(complex)
         local waists;
-        if not (IsSimplicialSurface(complex) and IsClosedSurface(complex) and
+        if not (IsSimplicialSurface(complex) and IsClosedComplex(complex) and
                 EulerCharacteristic(complex)=2 and IsVertexFaithful(complex)) then
                 return false;
         fi;
@@ -864,7 +871,7 @@ InstallMethod( InnerVertices, "for a polygonal surface",
     end
 );
 InstallMethod( InnerVertices, "for a closed twisted polygonal complex",
-    [IsTwistedPolygonalComplex and IsClosedSurface],
+    [IsTwistedPolygonalComplex and IsClosedComplex],
     function(complex)
         return VerticesAttributeOfComplex(complex);
     end
@@ -924,7 +931,7 @@ InstallMethod( BoundaryVertices, "for a polygonal complex",
 );
 # Special case closed surface
 InstallMethod( BoundaryVertices, "for a closed twisted polygonal complex",
-    [IsTwistedPolygonalComplex and IsClosedSurface],
+    [IsTwistedPolygonalComplex and IsClosedComplex],
     function(complex)
         return [];
     end
@@ -1226,7 +1233,7 @@ InstallMethod( BoundaryEdges, "for a twisted polygonal complex",
     end
 );
 InstallMethod( BoundaryEdges, "for a closed polygonal complex",
-    [IsPolygonalComplex and IsClosedSurface],
+    [IsPolygonalComplex and IsClosedComplex],
     function(complex)
         return [];
     end

--- a/gap/deprecated/wild_simplicial_surface.gi
+++ b/gap/deprecated/wild_simplicial_surface.gi
@@ -554,7 +554,7 @@ end);
 ##
 ##	Check connectivity
 ##
-InstallMethod( IsConnected, "for a wild simplicial surface",
+InstallMethod( IsConnectedSurface, "for a wild simplicial surface",
 	[IsWildSimplicialSurface],
 	function(simpsurf)
 		return Length( Orbits( GroupOfWildSimplicialSurface(simpsurf), 

--- a/gap/deprecated/wild_simplicial_surface.gi
+++ b/gap/deprecated/wild_simplicial_surface.gi
@@ -566,7 +566,7 @@ InstallMethod( IsConnectedSurface, "for a wild simplicial surface",
 ##	Check orientability
 ##
 #TODO how should be handle the assumption of connectivity?
-InstallMethod( IsOrientable, "for a wild simplicial surface", true, 
+InstallMethod( IsOrientableSurface, "for a wild simplicial surface", true, 
 	[ IsWildSimplicialSurface and IsPathConnected], 0,
         function(simpsurf)
 
@@ -616,7 +616,7 @@ InstallMethod( IsOrientable, "for a wild simplicial surface", true,
         elif Length(orb) = 2 then
             return true;
         fi;
-        Error("IsOrientable: unknown orientability of wild simplicial surface");
+        Error("IsOrientableSurface: unknown orientability of wild simplicial surface");
 
 	end
 );

--- a/library/discs/_recog.g
+++ b/library/discs/_recog.g
@@ -10,7 +10,7 @@ return function( queryList )
                 [EulerCharacteristic,1], 
                 [IsTriangularComplex,true],
                 [IsClosedSurface,false],
-                [IsConnected, true],
+                [IsConnectedComplex, true],
                 [IsOrientable, true]
                 ] do
             if query[1] = pair[1] and not __SIMPLICIAL_LibraryRecogUniqueResult(pair[2],query[2]) then

--- a/library/discs/_recog.g
+++ b/library/discs/_recog.g
@@ -9,9 +9,9 @@ return function( queryList )
         for pair in [
                 [EulerCharacteristic,1], 
                 [IsTriangularComplex,true],
-                [IsClosedSurface,false],
+                [IsClosedComplex,false],
                 [IsConnectedComplex, true],
-                [IsOrientable, true]
+                [IsOrientableComplex, true]
                 ] do
             if query[1] = pair[1] and not __SIMPLICIAL_LibraryRecogUniqueResult(pair[2],query[2]) then
                 return false;

--- a/library/simplicial spheres/_recog.g
+++ b/library/simplicial spheres/_recog.g
@@ -9,9 +9,9 @@ return function( queryList )
         for pair in [
                 [EulerCharacteristic,2], 
                 [IsTriangularComplex,true],
-                [IsClosedSurface,true],
+                [IsClosedComplex,true],
                 [IsConnectedComplex, true],
-                [IsOrientable, true]
+                [IsOrientableComplex, true]
                 ] do
             if query[1] = pair[1] and not __SIMPLICIAL_LibraryRecogUniqueResult(pair[2],query[2]) then
                 return false;

--- a/library/simplicial spheres/_recog.g
+++ b/library/simplicial spheres/_recog.g
@@ -10,7 +10,7 @@ return function( queryList )
                 [EulerCharacteristic,2], 
                 [IsTriangularComplex,true],
                 [IsClosedSurface,true],
-                [IsConnected, true],
+                [IsConnectedComplex, true],
                 [IsOrientable, true]
                 ] do
             if query[1] = pair[1] and not __SIMPLICIAL_LibraryRecogUniqueResult(pair[2],query[2]) then

--- a/unit_tests/Test_BorderCases_PolygonalComplex.g
+++ b/unit_tests/Test_BorderCases_PolygonalComplex.g
@@ -18,7 +18,7 @@ BindGlobal( "__SIMPLICIAL_Test_Properties", function()
     SetVerticesOfEdges(tet, tet_vertsOfEdges);
     SetEdgesOfFaces(tet, tet_edgesOfFaces);
     SetIsPolygonalComplex(tet, true);
-    SIMPLICIAL_TestAssert(IsClosedSurface(tet));
+    SIMPLICIAL_TestAssert(IsClosedComplex(tet));
 
 
     # Test the InnerVertices-method for the general case
@@ -32,7 +32,7 @@ BindGlobal( "__SIMPLICIAL_Test_Properties", function()
     tet := Objectify( TwistedPolygonalComplexType, rec() );
     SetVerticesOfEdges(tet, tet_vertsOfEdges);
     SetEdgesOfFaces(tet, tet_edgesOfFaces);
-    SetIsClosedSurface(tet, true);
+    SetIsClosedComplex(tet, true);
     SIMPLICIAL_TestAssert(InnerVertices(tet) = tet_verts);
 
 
@@ -47,7 +47,7 @@ BindGlobal( "__SIMPLICIAL_Test_Properties", function()
     tet := Objectify( TwistedPolygonalComplexType, rec() );
     SetVerticesOfEdges(tet, tet_vertsOfEdges);
     SetEdgesOfFaces(tet, tet_edgesOfFaces);
-    SetIsClosedSurface(tet, true);
+    SetIsClosedComplex(tet, true);
     SIMPLICIAL_TestAssert(BoundaryVertices(tet) = []);
 
     #TODO tests for other kinds of vertices and edges, preferably with more

--- a/unit_tests/Test_Inferences_PolygonalComplex.g
+++ b/unit_tests/Test_Inferences_PolygonalComplex.g
@@ -392,7 +392,7 @@ BindGlobal( "__SIMPLICIAL_Test_OrientabilityImplications", function()
     # If the surface is not orientable, then we don't have an orientation
     obj := Objectify( TwistedPolygonalComplexType, rec() );
     SetIsNotEdgeRamified(obj, true);
-    SetIsOrientable(obj, false);
+    SetIsOrientableComplex(obj, false);
     SetIsPolygonalComplex(obj, true);
     SIMPLICIAL_TestAssert(fail=Orientation(obj));
     SetFaces(obj, faces);
@@ -405,12 +405,12 @@ BindGlobal( "__SIMPLICIAL_Test_OrientabilityImplications", function()
     SetIsPolygonalComplex(obj, true);
     SetIsNotEdgeRamified(obj, true);
     SetOrientation( obj, List(perim, p -> VertexEdgePathNC(obj,p) ) );
-    SIMPLICIAL_TestAssert(IsOrientable(obj));
+    SIMPLICIAL_TestAssert(IsOrientableComplex(obj));
     obj := Objectify( TwistedPolygonalComplexType, rec() );
     SetIsPolygonalComplex(obj, true);
     SetIsNotEdgeRamified(obj, true);
     SetOrientation( obj, fail );
-    SIMPLICIAL_TestAssert(not IsOrientable(obj));
+    SIMPLICIAL_TestAssert(not IsOrientableComplex(obj));
 end);
 
 #################################################################################

--- a/unit_tests/Test_Inferences_PolygonalComplex.g
+++ b/unit_tests/Test_Inferences_PolygonalComplex.g
@@ -265,77 +265,77 @@ BindGlobal( "__SIMPLICIAL_Test_ConnectivityImplications", function()
     # If the connected components are known, the connectivity is known
     obj := Objectify( TwistedPolygonalComplexType, rec() );
     SetConnectedComponentsAttributeOfComplex( obj, [] );
-    SIMPLICIAL_TestAssert(IsConnected(obj));
+    SIMPLICIAL_TestAssert(IsConnectedComplex(obj));
 
     obj := Objectify( TwistedPolygonalComplexType, rec() );
     SetConnectedComponentsAttributeOfComplex( obj, [ 1 ] );
-    SIMPLICIAL_TestAssert(IsConnected(obj));
+    SIMPLICIAL_TestAssert(IsConnectedComplex(obj));
 
     obj := Objectify( TwistedPolygonalComplexType, rec() );
     SetConnectedComponentsAttributeOfComplex( obj, [ 1, 2 ] );
-    SIMPLICIAL_TestAssert(not IsConnected(obj));
+    SIMPLICIAL_TestAssert(not IsConnectedComplex(obj));
 
 
     # If the strongly connected components are known, the strong connectivity is known
     obj := Objectify( TwistedPolygonalComplexType, rec() );
     SetStronglyConnectedComponentsAttributeOfComplex( obj, [] );
-    SIMPLICIAL_TestAssert(IsStronglyConnected(obj));
+    SIMPLICIAL_TestAssert(IsStronglyConnectedComplex(obj));
 
     obj := Objectify( TwistedPolygonalComplexType, rec() );
     SetStronglyConnectedComponentsAttributeOfComplex( obj, [ obj ] );
-    SIMPLICIAL_TestAssert(IsStronglyConnected(obj));
+    SIMPLICIAL_TestAssert(IsStronglyConnectedComplex(obj));
 
     obj := Objectify( TwistedPolygonalComplexType, rec() );
     SetStronglyConnectedComponentsAttributeOfComplex( obj, [ 1, 2 ] );
-    SIMPLICIAL_TestAssert(not IsStronglyConnected(obj));
+    SIMPLICIAL_TestAssert(not IsStronglyConnectedComplex(obj));
 
 
     # If there is more than one connected component, the complex is not strongly connected
     obj := Objectify( TwistedPolygonalComplexType, rec() );
     SetConnectedComponentsAttributeOfComplex(obj, [1,2]);
-    SIMPLICIAL_TestAssert(not IsStronglyConnected(obj));
+    SIMPLICIAL_TestAssert(not IsStronglyConnectedComplex(obj));
 
 
     # If the complex is not connected, it is not strongly connected
     obj := Objectify( TwistedPolygonalComplexType, rec() );
-    SetIsConnected(obj, false);
-    SIMPLICIAL_TestAssert(not IsStronglyConnected(obj));
+    SetIsConnectedComplex(obj, false);
+    SIMPLICIAL_TestAssert(not IsStronglyConnectedComplex(obj));
 
 
     # If a complex is connected, every face has the same connected component
     obj := Objectify( TwistedPolygonalComplexType, rec() );
     SetFaces(obj, [1]);
-    SetIsConnected(obj, true);
+    SetIsConnectedComplex(obj, true);
     SIMPLICIAL_TestAssert(ConnectedComponentOfFace(obj,1) = obj);
 
 
     # If a complex is strongly connected, every face has the same strongly connected component
     obj := Objectify( TwistedPolygonalComplexType, rec() );
     SetFaces(obj, [1]);
-    SetIsStronglyConnected(obj, true);
+    SetIsStronglyConnectedComplex(obj, true);
     SIMPLICIAL_TestAssert(StronglyConnectedComponentOfFace(obj,1) = obj);
 
 
     # If a complex is connected, there is only one connected component
     obj := Objectify( TwistedPolygonalComplexType, rec() );
-    SetIsConnected(obj, true);
+    SetIsConnectedComplex(obj, true);
     SIMPLICIAL_TestAssert(ConnectedComponentsAttributeOfComplex(obj)=[obj]);
 
 
     # If a complex is strongly connected, there is only one strongly connected component
     obj := Objectify( TwistedPolygonalComplexType, rec() );
-    SetIsStronglyConnected(obj, true);
+    SetIsStronglyConnectedComplex(obj, true);
     SIMPLICIAL_TestAssert(StronglyConnectedComponents(obj)=[obj]);
 
 
     # If there is only one strongly connected component, then the complex is connected
     obj := Objectify( TwistedPolygonalComplexType, rec() );
     SetStronglyConnectedComponentsAttributeOfComplex( obj, [] );
-    SIMPLICIAL_TestAssert(IsConnected(obj));
+    SIMPLICIAL_TestAssert(IsConnectedComplex(obj));
 
     obj := Objectify( TwistedPolygonalComplexType, rec() );
     SetStronglyConnectedComponentsAttributeOfComplex( obj, [obj] );
-    SIMPLICIAL_TestAssert(IsConnected(obj));
+    SIMPLICIAL_TestAssert(IsConnectedComplex(obj));
 
 
     # If we have a polygonal surface, connected = strongly connected
@@ -354,7 +354,7 @@ BindGlobal( "__SIMPLICIAL_Test_ConnectivityImplications", function()
     obj := Objectify( TwistedPolygonalComplexType, rec() );
     SetIsNotEdgeRamified(obj, true);
     SetIsNotVertexRamified(obj, true);
-    SetIsConnected(obj, true);
+    SetIsConnectedComplex(obj, true);
     SIMPLICIAL_TestAssert(StronglyConnectedComponents(obj)=[obj]);
 end);
 

--- a/unit_tests/Test_VEFComplex.g
+++ b/unit_tests/Test_VEFComplex.g
@@ -59,8 +59,8 @@ BindGlobal( "__SIMPLICIAL_Test_VEF_SpecialisedIncidence",
         SIMPLICIAL_TestAssert(NeighbourFaceByEdge(ball,1,2)=1);
 
         # Orientation
-        SIMPLICIAL_TestAssert(IsOrientable(torus));
-        SIMPLICIAL_TestAssert(IsOrientable(ball));
+        SIMPLICIAL_TestAssert(IsOrientableComplex(torus));
+        SIMPLICIAL_TestAssert(IsOrientableComplex(ball));
 
         # Euler-characteristic
         SIMPLICIAL_TestAssert(EulerCharacteristic(torus)=0);

--- a/unit_tests/Test_VEFComplex.g
+++ b/unit_tests/Test_VEFComplex.g
@@ -67,8 +67,8 @@ BindGlobal( "__SIMPLICIAL_Test_VEF_SpecialisedIncidence",
         SIMPLICIAL_TestAssert(EulerCharacteristic(ball)=2);
 
         # IsClosedSurface
-        SIMPLICIAL_TestAssert(IsClosedSurface(torus));
-        SIMPLICIAL_TestAssert(IsClosedSurface(ball));
+        SIMPLICIAL_TestAssert(IsClosedComplex(torus));
+        SIMPLICIAL_TestAssert(IsClosedComplex(ball));
 
         # EdgeDegrees
         SIMPLICIAL_TestAssert(EdgeDegreeOfVertex(torus,2)=3);


### PR DESCRIPTION
Issue #281 

I renamed IsOrientable, Is(Strongly)Connected and IsClosed such that each of them has a method for complexes and surfaces. This is to avoid duplication with methods of other packages.