### PR TITLE
Decrease the dependencies of other packages

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -123,8 +123,8 @@ PackageDoc := rec(
 
 Dependencies := rec(
   GAP := ">= 4.12",
-  NeededOtherPackages := [ [ "Grape", ">=4.8.2" ], [ "AttributeScheduler", ">=2018.08.03" ], ["Digraphs", ">=1.1.1"],[ "NautyTracesInterface", ">=0.2" ]],
-  SuggestedOtherPackages := [ [ "GAPDoc", ">= 1.6" ], ["AutoDoc", ">=2019.05.20"], [ "IO", ">=2.2" ]],
+  NeededOtherPackages := [ [ "AttributeScheduler", ">=2018.08.03" ], ["Digraphs", ">=1.1.1"],[ "NautyTracesInterface", ">=0.2" ]],
+  SuggestedOtherPackages := [ [ "GAPDoc", ">= 1.6" ], ["AutoDoc", ">=2019.05.20"], [ "IO", ">=2.2" ], [ "Grape", ">=4.8.2" ]],
   ExternalConditions := [ ],
 ),
 


### PR DESCRIPTION
This PR is work in progress...

The goal would be that our package only depends on Digraphs and AttributeScheduler, because NautyTracesInterface is not deposited by GAP. This would then by only a extension that is possible but not needed (see #311).